### PR TITLE
If postgress doesn't use the default port (5432), specify it

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -40,4 +40,6 @@ config :discuss, Discuss.Repo,
   password: "",
   database: "discuss_dev",
   hostname: "localhost",
-  pool_size: 10
+  pool_size: 10,
+  port: 15432
+


### PR DESCRIPTION
My postgres does not use the [default port](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/adapters/postgres.ex#L38) (5432). So i had to add port: 15432  to the dev config.

Also noted in the [ecto docs here](https://hexdocs.pm/ecto/Ecto.Adapters.Postgres.html#content)