### PR TITLE
Add link to create new topics

### DIFF
--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -10,6 +10,7 @@
     <title>Hello Discuss!</title>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.1/css/materialize.min.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   </head>
 
   <body>

--- a/web/templates/topic/index.html.eex
+++ b/web/templates/topic/index.html.eex
@@ -6,3 +6,9 @@
     </li>
   <% end %>
 </ul>
+
+<div class="fixed-action-btn">
+  <%= link to: topic_path(@conn, :new), class: "btn-floating btn-large waves-effect waves-light red" do %>
+    <i class="material-icons">add</i>
+  <% end %>
+</div>

--- a/web/templates/topic/index.html.eex
+++ b/web/templates/topic/index.html.eex
@@ -1,4 +1,4 @@
-<h2>Topics</h2>
+<h5>Topics</h5>
 <ul class="collection">
   <%= for topic <- @topics do %>
     <li class="collection-item">


### PR DESCRIPTION
- (unrelated) make the `Topics` heading a bit smaller
- Add a button (link) to take users to the new topic creation form
- Add the googleapis cdn for material-icons